### PR TITLE
Capture Exception instead of ApplicationException

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,7 @@ client.ExportEnv(client.ResolveEnv());
 ```
 
 ### Exceptions
-Any error encountered by the SecretHub client will be thrown as an `ApplicationException`. The full error message can be retrieved from the `Message` field.
-It is recommended to capture these exceptions as an `Exception`. 
+Any error encountered by the SecretHub client will be thrown as an `Exception`. The full error message can be retrieved from the `Message` field.
 ```csharp
 try 
 {


### PR DESCRIPTION
Exception is fordward-compatible for when we move to using custom exception types.