### PR TITLE
Fix checking for errors in ResolveEnv

### DIFF
--- a/Client.cs
+++ b/Client.cs
@@ -73,7 +73,10 @@ public class Client : global::System.IDisposable {
   }
 
   public System.Collections.Generic.Dictionary<string,string> ResolveEnv() {
-    var res = Newtonsoft.Json.JsonConvert.DeserializeObject<System.Collections.Generic.Dictionary<string, string>>(SecretHubXGOPINVOKE.Client_ResolveEnv(swigCPtr));
+    var temp = SecretHubXGOPINVOKE.Client_ResolveEnv(swigCPtr);
+    
+    if (SecretHubXGOPINVOKE.SWIGPendingException.Pending) throw SecretHubXGOPINVOKE.SWIGPendingException.Retrieve();
+    var res = Newtonsoft.Json.JsonConvert.DeserializeObject<System.Collections.Generic.Dictionary<string, string>>(temp);
     
     if (SecretHubXGOPINVOKE.SWIGPendingException.Pending) throw SecretHubXGOPINVOKE.SWIGPendingException.Retrieve();
     return res;

--- a/docker-makefile.mk
+++ b/docker-makefile.mk
@@ -53,6 +53,9 @@ TEST=secrethub://secrethub/xgo/dotnet/test/test-secret \
 OTHER_TEST=secrethub://secrethub/xgo/dotnet/test/other-test-secret \
 TEST_MORE_EQUALS=this=has=three=equals
 endef
+define TEST_ENV_VARS_FAIL
+TEST=secrethub://secrethub/xgo/dotnet/test/non-existent-secret
+endef
 .PHONY: test
 test: lib
 	@echo "Testing the library..."
@@ -63,7 +66,8 @@ ifeq (OS_VAR, Windows_NT)
 else
 	@mv libSecretHubXGO.so build
 endif
-	@$(TEST_ENV_VARS) dotnet test build/secrethub.dll --nologo
+	@$(TEST_ENV_VARS) dotnet test build/secrethub.dll --nologo --filter FullyQualifiedName!=SecretHubTest.TestSuite.TestResolveEnvFail
+	@$(TEST_ENV_VARS_FAIL) dotnet test build/secrethub.dll --nologo --filter FullyQualifiedName=SecretHubTest.TestSuite.TestResolveEnvFail
 	@make -f docker-makefile.mk clean --no-print-directory
 
 .PHONY: nupkg

--- a/secrethub.csproj
+++ b/secrethub.csproj
@@ -7,8 +7,7 @@
     <Authors>SecretHub</Authors>
     <Company>SecretHub</Company>
     <Description>
-      Client for the SecretHub API.
-      SecretHub is a secrets management tool that works for every engineer. Securely provision passwords and keys throughout your entire stack with just a few lines of code.
+      .NET client to read and manage secrets on SecretHub. For more info see: https://secrethub.io/
     </Description>
   </PropertyGroup>
     <ItemGroup>

--- a/secrethub.i
+++ b/secrethub.i
@@ -32,9 +32,9 @@
 // Map return value of ResolveEnv to Dictionary<string, string>.
 %typemap(cstype) char* ResolveEnv "System.Collections.Generic.Dictionary<string,string>"
 %typemap(csout, excode=SWIGEXCODE) char* ResolveEnv {
-    var temp = $imcall;
+    var jsonEnv = $imcall;
     $excode
-    var res = Newtonsoft.Json.JsonConvert.DeserializeObject<System.Collections.Generic.Dictionary<string, string>>(temp);
+    var res = Newtonsoft.Json.JsonConvert.DeserializeObject<System.Collections.Generic.Dictionary<string, string>>(jsonEnv);
     $excode
     return res;
 }

--- a/secrethub.i
+++ b/secrethub.i
@@ -32,7 +32,9 @@
 // Map return value of ResolveEnv to Dictionary<string, string>.
 %typemap(cstype) char* ResolveEnv "System.Collections.Generic.Dictionary<string,string>"
 %typemap(csout, excode=SWIGEXCODE) char* ResolveEnv {
-    var res = Newtonsoft.Json.JsonConvert.DeserializeObject<System.Collections.Generic.Dictionary<string, string>>($imcall);
+    var temp = $imcall;
+    $excode
+    var res = Newtonsoft.Json.JsonConvert.DeserializeObject<System.Collections.Generic.Dictionary<string, string>>(temp);
     $excode
     return res;
 }

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -63,6 +63,14 @@ namespace SecretHubTest
             System.Collections.Generic.IDictionary<string,string> res = client.ResolveEnv();
             Assert.Equal(secretValue, res[envVarName]);
         }
+
+        [Fact]
+        public void TestResolveEnvFail() {
+            var client = new SecretHub.Client();
+            var ex = Assert.Throws<ApplicationException>(() => client.ResolveEnv());
+            Regex expectedErrorRegex = new Regex(@"^.*\(server\.secret_not_found\) $");
+            Assert.True(expectedErrorRegex.IsMatch(ex.Message), "error should end in the (server.secret_not_found) error code");
+        }
         
         [Fact]
         public void TestExportEnv() {


### PR DESCRIPTION
There was no error checking in SWIG directly after the call to the shared library's `ResolveEnv` function, the error checking was only done after parsing the return value of `ResolveEnv` into a `Dictionary<string, string>`. Since if `ResolveEnv` fails it returns `null` the parsing function will also throw an exception as its parameter should not be null. This exception will overwrite the original exception, and only an `Argument should not be null` exception will be thrown to the user.

This PR fixes this issue by adding the error checking also directly after `ResolveEnv`.

This PR also adds a test for this. Note that this test has to be executed separately with a different environment as .NET apparently doesn't offer any way of changing the process environment.